### PR TITLE
fix: unlocked packages are not supported

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -334,11 +334,7 @@ impl Upgrade {
                     }
                     Err(AddPackageErr::Io(e)) => log::error!("upgrading package: {}", e),
                     Err(AddPackageErr::AlreadyNewerPackageInstalled) => {}
-                    Err(
-                        e @ (AddPackageErr::ConflictWithDependencies { .. }
-                        | AddPackageErr::DependencyNotFound { .. }
-                        | AddPackageErr::OfflineMode),
-                    ) => {
+                    Err(e) => {
                         log::warn!("upgrading {} to {}: {}", name, package.version, e);
                     }
                 }

--- a/src/vpm/mod.rs
+++ b/src/vpm/mod.rs
@@ -914,7 +914,7 @@ impl UnityProject {
             .ok()
             .flatten();
         if let Some(parsed) = &parsed {
-            if vpm_manifest.locked().contains_key(&parsed.name) {
+            if parsed.name == name && vpm_manifest.locked().contains_key(&parsed.name) {
                 return None;
             }
         }


### PR DESCRIPTION
Fixes #41 

- [x] Check dependency conflict
- [x] Check directory name conflict
- [x] Resist installing package with same name (id)
  - [x] on install the package
  - [x] on install dependencies