### PR TITLE
fix: support upm manifest without dependencies

### DIFF
--- a/vrc-get-vpm/src/unity_project/upm_manifest.rs
+++ b/vrc-get-vpm/src/unity_project/upm_manifest.rs
@@ -11,6 +11,7 @@ use tokio::{fs, io};
 
 #[derive(Debug, Deserialize)]
 struct Parsed {
+    #[serde(default)]
     dependencies: HashMap<String, UpmDependency>,
 }
 


### PR DESCRIPTION
Fix https://github.com/bdunderscore/ndmf/actions/runs/7599806460/job/20697245315?pr=125