### PR TITLE
chore: relax atomic ordering in LiteDbConnectionHolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog].
     - Please add alternative repository to user repository and enable this feature to use alternative repository instead of official / curated repository.
   - This feature is not stable yet. Using this feature will warn you about it and use at your own risk. `#362` `#365`
 - `vrc-get-litedb` crate which is NativeAOT based LiteDB wrapper for vrc-get `#320`
-- `vrc-get vcc` commands which is a command for vrc-get as a VCC project
+- `vrc-get vcc` commands which is a command for vrc-get as a VCC project `#369` `#396`
   - This feature is disabled by default. pass `--features experimental-vcc` to cargo to enable this feature. `#384` 
   - `vrc-get vcc project list` to list projects `#369`
   - `vrc-get vcc project add <path>` to add a project to project list `#369`

--- a/vrc-get-vpm/src/environment/litedb.rs
+++ b/vrc-get-vpm/src/environment/litedb.rs
@@ -29,7 +29,7 @@ impl LiteDbConnectionHolder {
     }
 
     fn get(&self) -> Option<&DatabaseConnection> {
-        let ptr = self.ptr.load(std::sync::atomic::Ordering::SeqCst);
+        let ptr = self.ptr.load(std::sync::atomic::Ordering::Acquire);
         if ptr.is_null() {
             None
         } else {
@@ -49,8 +49,8 @@ impl LiteDbConnectionHolder {
         match self.ptr.compare_exchange(
             std::ptr::null_mut(),
             ptr,
-            std::sync::atomic::Ordering::SeqCst,
-            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
         ) {
             Ok(_) => {
                 // success means the value is used so return the value


### PR DESCRIPTION
Fixes #385 