### PR TITLE
chore(cli): bump next version to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,7 +4143,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vrc-get"
-version = "1.6.2-beta.0"
+version = "1.7.0-beta.0"
 dependencies = [
  "anstyle",
  "clap",

--- a/vrc-get/Cargo.toml
+++ b/vrc-get/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrc-get"
-version = "1.6.2-beta.0"
+version = "1.7.0-beta.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
it has vrc-get downgrade which is a new feature