### PR TITLE
fix(gui): window name is not vrc-get-gui

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Message protrudes from toasts or dialogs `#469`
+- Window name should be `vrc-get-gui` but was `vrc-get GUI` `#474`
 
 ### Security
 

--- a/vrc-get-gui/Tauri.toml
+++ b/vrc-get-gui/Tauri.toml
@@ -17,7 +17,7 @@ allowlist = { all = false }
 active = false
 
 [[tauri.windows]]
-title = "vrc-get GUI"
+title = "vrc-get-gui"
 url = "/projects"
 
 fullscreen = false
@@ -33,7 +33,7 @@ targets = [
     "app", # needs for dmg
     "dmg",
 ]
-longDescription = "vrc-get GUI is a fast and open-source alternative VCC (VRChat Creator Companion) written in rust and tauri."
+longDescription = "vrc-get-gui is a fast and open-source alternative VCC (VRChat Creator Companion) written in rust and tauri."
 shortDescription = "an alternative VCC"
 identifier = "com.anataw12.vrc-get"
 category = "DeveloperTool"


### PR DESCRIPTION
Fixes #474 