### PR TITLE
fix(vpm): Empty `depeneencies` block of `locked` section in `vpm-manifest.json` is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Empty `depeneencies` block of `locked` section in `vpm-manifest.json` is removed `#478`
+  - This follows the changed behavior of the official VPM command.
 
 ### Security
 

--- a/vrc-get-vpm/src/unity_project/resolve.rs
+++ b/vrc-get-vpm/src/unity_project/resolve.rs
@@ -177,7 +177,7 @@ impl<IO: ProjectIo> UnityProject<IO> {
         for x in changes.get_all_installing() {
             virtual_locked_dependencies.insert(
                 x.name(),
-                LockedDependencyInfo::new(x.name(), x.version(), x.vpm_dependencies()),
+                LockedDependencyInfo::new(x.name(), x.version(), Some(x.vpm_dependencies())),
             );
         }
 


### PR DESCRIPTION
Fixes #473 